### PR TITLE
Update to core22, fuse-3.17.1, and sshfs-3.7.3

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -8,8 +8,7 @@ license: GPL-2.0
 
 version: git
 confinement: strict
-base: bare
-build-base: core18
+base: core22
 grade: stable
 
 apps:
@@ -17,13 +16,12 @@ apps:
     command: bin/busybox env
     environment:
       LD_LIBRARY_PATH: $SNAP/lib
-    adapter: none
 
 parts:
   libfuse:
     plugin: meson
     source: https://github.com/libfuse/libfuse.git
-    source-tag: fuse-3.9.0
+    source-tag: fuse-3.17.1
     meson-parameters:
     - --prefix=/
     - --libdir=lib/
@@ -32,6 +30,8 @@ parts:
     - -Dexamples=false
     build-packages:
     - pkg-config
+    - meson
+    - ninja-build
     stage:
     - -bin/
     - -etc/
@@ -47,12 +47,14 @@ parts:
     - libfuse
     plugin: meson
     source: https://github.com/libfuse/sshfs.git
-    source-tag: sshfs-3.7.0
+    source-tag: sshfs-3.7.3
     meson-parameters:
     - --prefix=/
     - --buildtype=release
     build-packages:
     - libglib2.0-dev
+    - meson
+    - ninja-build
     stage:
     - -sbin/
 


### PR DESCRIPTION
This PR modernizes the multipass-sshfs snap package with several important updates:

Changes
- Updated base from 'bare' to 'core22' (Ubuntu 22.04 LTS)
- Removed deprecated 'build-base: core18' configuration as it's not needed with core22
- Updated libfuse from 3.9.0 to 3.17.1
- Updated sshfs from 3.7.0 to 3.7.3
- Removed deprecated 'adapter: none' configuration which is no longer supported in newer snapcraft versions
- Added meson and ninja-build as explicit build dependencies for both libfuse and sshfs parts

Testing

The updated snap was tested with multipass 1.15.1 using the following process:

Checkout the `update-multipass-sshfs`
Build the snap locally
`snapcraft`
Create a test Multipass instance:
`multipass launch --name test-sshfs`
Transfer and installed the snap in the instance:
`multipass transfer multipass-sshfs_1.1-dirty_amd64.snap test-sshfs:`
`multipass exec test-sshfs -- sudo snap install --dangerous multipass-sshfs_1.1-dirty_amd64.snap`
Verify mount functionality:
```
# Create test directory and mount it
mkdir test_mount
multipass mount test_mount test-sshfs:/home/ubuntu/test_mount

# Test file creation and visibility
echo "test file" > test_mount/test.txt
multipass exec test-sshfs -- cat /home/ubuntu/test_mount/test.txt
```